### PR TITLE
Add CRUD operations on mutable nodes

### DIFF
--- a/src/main/java/org/seedstack/coffig/ConfigurationException.java
+++ b/src/main/java/org/seedstack/coffig/ConfigurationException.java
@@ -8,11 +8,15 @@
 package org.seedstack.coffig;
 
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 public class ConfigurationException extends RuntimeException {
 
     public static final BiFunction<Class<?>,Class<?>, String> INCORRECT_MERGE =
             (c1, c2) -> String.format("Attempt to merge a %s with a %s", c1.getCanonicalName(), c2.getCanonicalName());
+
+    public static final Function<Object, String> ILLEGAL_MUTATION =
+            (c) -> "Try to update an immutable TreeNode: " + c.getClass();
 
     public ConfigurationException(String message) {
         super(message);

--- a/src/main/java/org/seedstack/coffig/data/AbstractTreeNode.java
+++ b/src/main/java/org/seedstack/coffig/data/AbstractTreeNode.java
@@ -1,0 +1,53 @@
+package org.seedstack.coffig.data;
+
+import org.seedstack.coffig.PropertyNotFoundException;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * @author Pierre THIROUIN (pierre.thirouin@ext.inetpsa.com)
+ */
+public abstract class AbstractTreeNode implements TreeNode {
+
+    public TreeNode search(String prefix) {
+        String[] split = prefix.split("\\.", 2);
+        try {
+            TreeNode treeNode = doSearch(split[0]);
+            if (split.length == 2) {
+                treeNode = treeNode.search(split[1]);
+            }
+            return treeNode;
+        } catch (PropertyNotFoundException e) {
+            if (e.getCause() == null) {
+                throw new PropertyNotFoundException(prefix);
+            } else {
+                throw new PropertyNotFoundException(e.getCause(), prefix);
+            }
+        }
+    }
+
+    protected String indent(String s) {
+        return Arrays.stream(s.split("\n")).map(line -> "  " + line).collect(Collectors.joining("\n"));
+    }
+
+    protected TreeNode doSearch(String name) {
+        throw new PropertyNotFoundException(name);
+    }
+
+    public TreeNode value(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    public String value() {
+        throw new UnsupportedOperationException();
+    }
+
+    public TreeNode[] values() {
+        throw new UnsupportedOperationException();
+    }
+
+    public TreeNode merge(TreeNode otherNode) {
+        return otherNode;
+    }
+}

--- a/src/main/java/org/seedstack/coffig/data/AbstractTreeNode.java
+++ b/src/main/java/org/seedstack/coffig/data/AbstractTreeNode.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.seedstack.coffig.data;
 
 import org.seedstack.coffig.PropertyNotFoundException;

--- a/src/main/java/org/seedstack/coffig/data/ArrayNode.java
+++ b/src/main/java/org/seedstack/coffig/data/ArrayNode.java
@@ -9,38 +9,48 @@ package org.seedstack.coffig.data;
 
 import org.seedstack.coffig.PropertyNotFoundException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
-public class ArrayNode extends TreeNode {
-    private final TreeNode[] childNodes;
+public class ArrayNode extends AbstractTreeNode {
+    protected final List<TreeNode> childNodes;
 
     public ArrayNode(TreeNode... childNodes) {
-        this.childNodes = childNodes;
+        this.childNodes = new ArrayList<>(Arrays.asList(childNodes));
     }
 
     public ArrayNode(String... childNodes) {
-        List<ValueNode> valueNodes = Arrays.stream(childNodes).map(ValueNode::new).collect(toList());
-        this.childNodes = valueNodes.toArray(new TreeNode[valueNodes.size()]);
+        this.childNodes = Arrays.stream(childNodes).map(ValueNode::new).collect(toList());
+    }
+
+    public ArrayNode(List<TreeNode> childNodes) {
+        this.childNodes = new ArrayList<>(childNodes);
     }
 
     @Override
     public TreeNode doSearch(String name) {
         try {
             Integer integer = Integer.valueOf(name);
-            return childNodes[integer];
+            return childNodes.get(integer);
         } catch (NumberFormatException e) {
             throw new PropertyNotFoundException("Configuration array node is expected a number as index, but found: " + name);
-        } catch (ArrayIndexOutOfBoundsException e2) {
+        } catch (IndexOutOfBoundsException e2) {
             throw new PropertyNotFoundException(e2, name);
         }
     }
 
     @Override
     public TreeNode[] values() {
-        return childNodes;
+        return childNodes.toArray(new TreeNode[childNodes.size()]);
+    }
+
+    public TreeNode value(int index) {
+        return childNodes.get(index);
     }
 
     @Override
@@ -48,11 +58,20 @@ public class ArrayNode extends TreeNode {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ArrayNode arrayNode = (ArrayNode) o;
-        return Arrays.equals(childNodes, arrayNode.childNodes);
+        return childNodes.equals(arrayNode.childNodes);
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(childNodes);
+        return childNodes.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        if (childNodes.size() > 0 && childNodes.get(0) instanceof ValueNode) {
+            return childNodes.stream().map(item -> "- " + item.toString()).collect(joining("\n"));
+        } else {
+            return childNodes.stream().map(item -> "-\n" + indent(item.toString())).collect(joining("\n"));
+        }
     }
 }

--- a/src/main/java/org/seedstack/coffig/data/MapNode.java
+++ b/src/main/java/org/seedstack/coffig/data/MapNode.java
@@ -14,11 +14,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.seedstack.coffig.ConfigurationException.INCORRECT_MERGE;
 
-public class MapNode extends TreeNode {
-    private final Map<String, PairNode> childNodes;
+public class MapNode extends AbstractTreeNode {
+    protected final Map<String, PairNode> childNodes;
 
     public MapNode(PairNode... childNodes) {
         this.childNodes = new HashMap<>();
@@ -36,7 +37,7 @@ public class MapNode extends TreeNode {
     }
 
     @Override
-    protected TreeNode doSearch(String name) {
+    public TreeNode doSearch(String name) {
         return value(name);
     }
 
@@ -82,5 +83,10 @@ public class MapNode extends TreeNode {
     @Override
     public int hashCode() {
         return Objects.hash(childNodes);
+    }
+
+    @Override
+    public String toString() {
+        return childNodes.values().stream().map(Object::toString).collect(Collectors.joining("\n"));
     }
 }

--- a/src/main/java/org/seedstack/coffig/data/PairNode.java
+++ b/src/main/java/org/seedstack/coffig/data/PairNode.java
@@ -9,13 +9,15 @@ package org.seedstack.coffig.data;
 
 import org.seedstack.coffig.ConfigurationException;
 
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.seedstack.coffig.ConfigurationException.INCORRECT_MERGE;
 
-public class PairNode extends TreeNode {
-    private String name;
-    private TreeNode value;
+public class PairNode extends AbstractTreeNode {
+    protected String name;
+    protected TreeNode value;
 
     public PairNode(String name, TreeNode value) {
         this.name = name;
@@ -59,5 +61,14 @@ public class PairNode extends TreeNode {
     @Override
     public int hashCode() {
         return Objects.hash(name, value);
+    }
+
+    @Override
+    public String toString() {
+        if (value instanceof ValueNode) {
+            return name + ": " + value.toString();
+        } else {
+            return name + ":\n" + indent(value.toString());
+        }
     }
 }

--- a/src/main/java/org/seedstack/coffig/data/TreeNode.java
+++ b/src/main/java/org/seedstack/coffig/data/TreeNode.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
- * <p>
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/src/main/java/org/seedstack/coffig/data/TreeNode.java
+++ b/src/main/java/org/seedstack/coffig/data/TreeNode.java
@@ -1,50 +1,21 @@
 /**
  * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
- *
+ * <p>
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package org.seedstack.coffig.data;
 
-import org.seedstack.coffig.PropertyNotFoundException;
+public interface TreeNode {
 
-public abstract class TreeNode {
+    TreeNode search(String prefix);
 
-    public TreeNode search(String prefix) {
-        String[] split = prefix.split("\\.", 2);
-        try {
-            TreeNode treeNode = doSearch(split[0]);
-            if (split.length == 2) {
-                treeNode = treeNode.search(split[1]);
-            }
-            return treeNode;
-        } catch (PropertyNotFoundException e) {
-            if (e.getCause() == null) {
-                throw new PropertyNotFoundException(prefix);
-            } else {
-                throw new PropertyNotFoundException(e.getCause(), prefix);
-            }
-        }
-    }
+    TreeNode value(String name);
 
-    protected TreeNode doSearch(String name) {
-        throw new PropertyNotFoundException(name);
-    }
+    String value();
 
-    public TreeNode value(String name) {
-        throw new UnsupportedOperationException();
-    }
+    TreeNode[] values();
 
-    public String value() {
-        throw new UnsupportedOperationException();
-    }
-
-    public TreeNode[] values() {
-        throw new UnsupportedOperationException();
-    }
-
-    public TreeNode merge(TreeNode otherNode) {
-        return otherNode;
-    }
+    TreeNode merge(TreeNode otherNode);
 }

--- a/src/main/java/org/seedstack/coffig/data/ValueNode.java
+++ b/src/main/java/org/seedstack/coffig/data/ValueNode.java
@@ -9,8 +9,8 @@ package org.seedstack.coffig.data;
 
 import java.util.Objects;
 
-public class ValueNode extends TreeNode {
-    private String value;
+public class ValueNode extends AbstractTreeNode {
+    protected String value;
 
     public ValueNode(String value) {
         this.value = value;
@@ -32,5 +32,10 @@ public class ValueNode extends TreeNode {
     @Override
     public int hashCode() {
         return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return value;
     }
 }

--- a/src/main/java/org/seedstack/coffig/data/mutable/MutableArrayNode.java
+++ b/src/main/java/org/seedstack/coffig/data/mutable/MutableArrayNode.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.coffig.data.mutable;
+
+import org.seedstack.coffig.data.ArrayNode;
+import org.seedstack.coffig.data.TreeNode;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class MutableArrayNode extends ArrayNode implements MutableTreeNode {
+    public MutableArrayNode(TreeNode... childNodes) {
+        super(childNodes);
+    }
+
+    public MutableArrayNode(String... childNodes) {
+        super(childNodes);
+    }
+
+    public MutableArrayNode(List<TreeNode> childNodes) {
+        super(childNodes);
+    }
+
+    public MutableArrayNode() {
+        super(new ArrayList<>());
+    }
+
+    public void add(TreeNode treeNode) {
+        childNodes.add(treeNode);
+    }
+
+    public void add(int index, TreeNode treeNode) {
+        childNodes.add(index, treeNode);
+    }
+
+    public boolean addAll(Collection<? extends TreeNode> c) {
+        return childNodes.addAll(c);
+    }
+
+    public void remove(TreeNode treeNode) {
+        childNodes.remove(treeNode);
+    }
+
+    public void clear() {
+        childNodes.clear();
+    }
+
+    @Override
+    public void set(String name, TreeNode value) {
+        Prefix prefix = new Prefix(name);
+        TreeNode treeNode;
+        if (prefix.tail.isPresent()) {
+            treeNode = getOrCreateTreeNode(prefix);
+            ((MutableTreeNode) treeNode).set(prefix.tail.get(), value);
+        } else {
+            treeNode = value;
+        }
+
+        if (prefix.index == childNodes.size()) {
+            childNodes.add(treeNode);
+        } else {
+            childNodes.set(prefix.index, treeNode);
+        }
+    }
+
+    private TreeNode getOrCreateTreeNode(Prefix prefix) {
+        TreeNode treeNode;
+        if (!isIndexPresent(prefix)) {
+            treeNode = createTreeNode(prefix);
+        } else {
+            treeNode = childNodes.get(prefix.index);
+            assertMutable(treeNode);
+        }
+        return treeNode;
+    }
+
+    private TreeNode createTreeNode(Prefix prefix) {
+        TreeNode treeNode;
+        if (new Prefix(prefix.tail.get()).isArray) {
+            treeNode = new MutableArrayNode();
+        } else {
+            treeNode = new MutableMapNode();
+        }
+        return treeNode;
+    }
+
+    @Override
+    public void remove(String name) {
+        Prefix prefix = new Prefix(name);
+        if (prefix.tail.isPresent()) {
+            if (isIndexPresent(prefix)) {
+                TreeNode treeNode = childNodes.get(prefix.index);
+                assertMutable(treeNode);
+
+                MutableTreeNode mutableTreeNode = (MutableTreeNode) treeNode;
+                mutableTreeNode.remove(prefix.tail.get());
+                if (mutableTreeNode.isEmpty()) {
+                    childNodes.remove(prefix.index);
+                }
+            }
+        } else {
+            childNodes.remove(prefix.index);
+        }
+    }
+
+    private boolean isIndexPresent(Prefix prefix) {
+        return childNodes.size() > prefix.index;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return childNodes.isEmpty();
+    }
+}

--- a/src/main/java/org/seedstack/coffig/data/mutable/MutableMapNode.java
+++ b/src/main/java/org/seedstack/coffig/data/mutable/MutableMapNode.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
- * <p>
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/src/main/java/org/seedstack/coffig/data/mutable/MutableMapNode.java
+++ b/src/main/java/org/seedstack/coffig/data/mutable/MutableMapNode.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
+ * <p>
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.coffig.data.mutable;
+
+import org.seedstack.coffig.data.MapNode;
+import org.seedstack.coffig.data.PairNode;
+import org.seedstack.coffig.data.TreeNode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MutableMapNode extends MapNode implements MutableTreeNode {
+
+    public MutableMapNode(PairNode... childNodes) {
+        super(childNodes);
+    }
+
+    public MutableMapNode(Map<String, PairNode> newChildNodes) {
+        super(newChildNodes);
+    }
+
+    public MutableMapNode() {
+        super(new HashMap<>());
+    }
+
+    public PairNode put(String key, PairNode value) {
+        return childNodes.put(key, value);
+    }
+
+    public void putAll(Map<? extends String, ? extends PairNode> m) {
+        childNodes.putAll(m);
+    }
+
+    public void clear() {
+        childNodes.clear();
+    }
+
+    @Override
+    public void set(String name, TreeNode value) {
+        Prefix prefix = new Prefix(name);
+        if (prefix.tail.isPresent()) {
+            MutablePairNode mutablePairNode;
+            if (childNodes.containsKey(prefix.head)) {
+                PairNode pairNode = childNodes.get(prefix.head);
+                assertMutable(pairNode);
+                mutablePairNode = (MutablePairNode) pairNode;
+            } else {
+                mutablePairNode = new MutablePairNode();
+            }
+            mutablePairNode.set(name, value);
+            childNodes.put(prefix.head, mutablePairNode);
+        } else {
+            childNodes.put(prefix.head, new MutablePairNode(prefix.head, value));
+        }
+    }
+
+    @Override
+    public void remove(String name) {
+        Prefix prefix = new Prefix(name);
+        if (prefix.tail.isPresent()) {
+            if (childNodes.containsKey(prefix.head)) {
+                TreeNode treeNode = childNodes.get(prefix.head);
+                assertMutable(treeNode);
+                MutableTreeNode mutableTreeNode = (MutableTreeNode) treeNode;
+                mutableTreeNode.remove(prefix.tail.get());
+                if (mutableTreeNode.isEmpty()) {
+                    childNodes.remove(prefix.head);
+                }
+            }
+        } else {
+            childNodes.remove(prefix.head);
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return childNodes.isEmpty();
+    }
+}

--- a/src/main/java/org/seedstack/coffig/data/mutable/MutablePairNode.java
+++ b/src/main/java/org/seedstack/coffig/data/mutable/MutablePairNode.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
- * <p>
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/src/main/java/org/seedstack/coffig/data/mutable/MutablePairNode.java
+++ b/src/main/java/org/seedstack/coffig/data/mutable/MutablePairNode.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
+ * <p>
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.coffig.data.mutable;
+
+import org.seedstack.coffig.data.PairNode;
+import org.seedstack.coffig.data.TreeNode;
+
+import java.util.Optional;
+
+public class MutablePairNode extends PairNode implements MutableTreeNode {
+    public MutablePairNode(String name, TreeNode value) {
+        super(name, value);
+    }
+
+    public MutablePairNode(String name, String value) {
+        super(name, value);
+    }
+
+    public MutablePairNode(String name, String... values) {
+        super(name, values);
+    }
+
+    public MutablePairNode() {
+        super(null, (TreeNode) null);
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setValue(TreeNode value) {
+        this.value = value;
+    }
+
+    @Override
+    public void set(String name, TreeNode value) {
+        Prefix prefix = new Prefix(name);
+        setName(prefix.head);
+
+        if (prefix.tail.isPresent()) {
+            TreeNode treeNode = getOrCreateTreeNode(prefix);
+            ((MutableTreeNode) treeNode).set(prefix.tail.get(), value);
+            this.value = treeNode;
+        } else {
+            this.value = value;
+        }
+    }
+
+    private TreeNode getOrCreateTreeNode(Prefix prefix) {
+        TreeNode treeNode;
+        if (this.value == null) {
+            treeNode = createTreeNode(prefix);
+        } else {
+            treeNode = this.value;
+            assertMutable(treeNode);
+        }
+        return treeNode;
+    }
+
+    private TreeNode createTreeNode(Prefix prefix) {
+        TreeNode treeNode;
+        if (new Prefix(prefix.tail.get()).isArray) {
+            treeNode = new MutableArrayNode();
+        } else {
+            treeNode = new MutableMapNode();
+        }
+        return treeNode;
+    }
+
+    @Override
+    public void remove(String prefix) {
+        ((MutableTreeNode) this.value).remove(prefix);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return ((MutableTreeNode) this.value).isEmpty();
+    }
+}

--- a/src/main/java/org/seedstack/coffig/data/mutable/MutableTreeNode.java
+++ b/src/main/java/org/seedstack/coffig/data/mutable/MutableTreeNode.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
- * <p>
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/src/main/java/org/seedstack/coffig/data/mutable/MutableTreeNode.java
+++ b/src/main/java/org/seedstack/coffig/data/mutable/MutableTreeNode.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
+ * <p>
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.coffig.data.mutable;
+
+import org.seedstack.coffig.ConfigurationException;
+import org.seedstack.coffig.data.TreeNode;
+
+public interface MutableTreeNode extends TreeNode {
+
+    default void assertMutable(TreeNode treeNode) {
+        if (!MutableTreeNode.class.isAssignableFrom(treeNode.getClass())) {
+            throw new ConfigurationException(ConfigurationException.ILLEGAL_MUTATION.apply(treeNode));
+        }
+    }
+
+    void set(String prefix, TreeNode value);
+
+    void remove(String prefix);
+
+    boolean isEmpty();
+}

--- a/src/main/java/org/seedstack/coffig/data/mutable/Prefix.java
+++ b/src/main/java/org/seedstack/coffig/data/mutable/Prefix.java
@@ -1,0 +1,38 @@
+package org.seedstack.coffig.data.mutable;
+
+import java.util.Optional;
+
+class Prefix {
+    String head;
+    Optional<String> tail;
+    int index;
+    boolean isArray;
+
+    public Prefix(String prefix) {
+        String[] splitPrefix = prefix.split("\\.", 2);
+        head = splitPrefix[0];
+        setTail(splitPrefix);
+        setIndex();
+    }
+
+    private void setTail(String[] splitPrefix) {
+        if (splitPrefix.length == 2) {
+            tail = Optional.of(splitPrefix[1]);
+        } else {
+            tail = Optional.empty();
+        }
+    }
+
+    private void setIndex() {
+        try {
+            index = Integer.valueOf(head);
+            if (index >= 0) {
+                isArray = true;
+            } else {
+                throw new ArrayIndexOutOfBoundsException();
+            }
+        } catch (NumberFormatException e) {
+            isArray = false;
+        }
+    }
+}

--- a/src/main/java/org/seedstack/coffig/data/mutable/Prefix.java
+++ b/src/main/java/org/seedstack/coffig/data/mutable/Prefix.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.seedstack.coffig.data.mutable;
 
 import java.util.Optional;

--- a/src/test/java/org/seedstack/coffig/data/MutableTreeNodeTest.java
+++ b/src/test/java/org/seedstack/coffig/data/MutableTreeNodeTest.java
@@ -11,7 +11,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.seedstack.coffig.PropertyNotFoundException;
 
-public class TreeSampleTest {
+public class MutableTreeNodeTest {
 
     MapNode root = new MapNode(
             new PairNode("id", "foo"),
@@ -106,5 +106,23 @@ public class TreeSampleTest {
         } catch (PropertyNotFoundException e) {
             Assertions.assertThat(e.getCause()).isNotNull();
         }
+    }
+
+    @Test
+    public void testToString() throws Exception {
+        Assertions.assertThat(root.toString()).isEqualTo(
+                "server:\n" +
+                "  port: 80\n" +
+                "  host: localhost\n" +
+                "datasources:\n" +
+                "  -\n" +
+                "    driver: org.hsqldb.jdbcDriver\n" +
+                "    name: ds1\n" +
+                "    url: jdbc:hsqldb:hsql://localhost:9001/ds1\n" +
+                "name: The Foo app\n" +
+                "id: foo\n" +
+                "users:\n" +
+                "  - u123456\n" +
+                "  - u456789");
     }
 }

--- a/src/test/java/org/seedstack/coffig/data/mutable/MutableNodesTest.java
+++ b/src/test/java/org/seedstack/coffig/data/mutable/MutableNodesTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
- * <p>
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/src/test/java/org/seedstack/coffig/data/mutable/MutableNodesTest.java
+++ b/src/test/java/org/seedstack/coffig/data/mutable/MutableNodesTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2013-2016, The SeedStack authors <http://seedstack.org>
+ * <p>
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.coffig.data.mutable;
+
+import org.junit.Test;
+import org.seedstack.coffig.PropertyNotFoundException;
+import org.seedstack.coffig.data.MapNode;
+import org.seedstack.coffig.data.PairNode;
+import org.seedstack.coffig.data.TreeNode;
+import org.seedstack.coffig.data.ValueNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class MutableNodesTest {
+
+    @Test
+    public void testMutableNodes() {
+        MutableMapNode mapNode = new MutableMapNode();
+        MutableArrayNode arrayNode = new MutableArrayNode();
+        arrayNode.add(new ValueNode("foo"));
+        arrayNode.add(new ValueNode("bar"));
+        arrayNode.add(0, new ValueNode("foo"));
+        MutablePairNode pairNode = new MutablePairNode();
+        pairNode.setName("custom");
+        pairNode.setValue(arrayNode);
+        mapNode.put("custom", pairNode);
+
+        assertThat(mapNode.search("custom.0").value()).isEqualTo("foo");
+        assertThat(mapNode.search("custom.1").value()).isEqualTo("foo");
+        assertThat(mapNode.search("custom.2").value()).isEqualTo("bar");
+    }
+
+    // Set
+
+    @Test
+    public void testSetValue() {
+        MutableMapNode mapNode = new MutableMapNode();
+        mapNode.set("custom", new ValueNode("foo"));
+        assertThat(mapNode.search("custom").value()).isEqualTo("foo");
+    }
+
+    @Test
+    public void testSetUpdateMap() {
+        MutableMapNode mapNode = new MutableMapNode();
+        mapNode.set("custom.node.old", new ValueNode("foo"));
+        assertThat(mapNode.search("custom.node.old").value()).isEqualTo("foo");
+        mapNode.set("custom.node.new", new ValueNode("bar"));
+        assertThat(mapNode.search("custom.node.old").value()).isEqualTo("foo");
+        assertThat(mapNode.search("custom.node.new").value()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testSetArray() {
+        MutableMapNode mapNode = new MutableMapNode();
+        mapNode.set("custom.foo.0", new ValueNode("val1"));
+        assertThat(mapNode.search("custom.foo.0").value()).isEqualTo("val1");
+        mapNode.set("custom.foo.1", new ValueNode("val2"));
+        assertThat(mapNode.search("custom.foo.1").value()).isEqualTo("val2");
+        mapNode.set("custom.foo.1", new ValueNode("val3"));
+        assertThat(mapNode.search("custom.foo.0").value()).isEqualTo("val1");
+        assertThat(mapNode.search("custom.foo.1").value()).isEqualTo("val3");
+    }
+
+    @Test
+    public void testSetArrayOfNode() {
+        MutableMapNode mapNode = new MutableMapNode();
+        mapNode.set("arr.0.custom", new ValueNode("foo"));
+        assertThat(mapNode.search("arr.0.custom").value()).isEqualTo("foo");
+        mapNode.set("arr.0.custom2", new ValueNode("foo2"));
+        assertThat(mapNode.search("arr.0.custom2").value()).isEqualTo("foo2");
+    }
+
+    @Test
+    public void testSetTreeNode() {
+        MutableMapNode mapNode = new MutableMapNode();
+        mapNode.set("arr.0.custom", new MapNode(new PairNode("key", new ValueNode("val"))));
+        assertThat(mapNode.search("arr.0.custom.key").value()).isEqualTo("val");
+    }
+
+    // Remove
+
+    @Test
+    public void testRemoveMapNode() {
+        MutableMapNode mapNode = new MutableMapNode();
+        mapNode.set("custom.key", new ValueNode("val"));
+
+        mapNode.remove("custom.key");
+
+        assertRemovedKey(mapNode, "custom");
+    }
+
+    private void assertRemovedKey(TreeNode treeNode, String prefix) {
+        try {
+            treeNode.search(prefix);
+            failBecauseExceptionWasNotThrown(PropertyNotFoundException.class);
+        } catch (PropertyNotFoundException e) {
+            assertThat(e).hasMessage("Property \"" + prefix + "\" was not found");
+        }
+    }
+
+    @Test
+    public void testRemoveOnlyEmptyMapNodes() {
+        MutableMapNode mapNode = new MutableMapNode();
+        mapNode.set("custom.property.key1", new ValueNode("val"));
+        mapNode.set("custom.key2", new ValueNode("val"));
+
+        mapNode.remove("custom.property.key1");
+
+        assertRemovedKey(mapNode, "custom.property.key1");
+        assertRemovedKey(mapNode, "custom.property");
+        assertThat(mapNode.search("custom.key2").value()).isEqualTo("val");
+    }
+
+    @Test
+    public void testRemoveOnlyEmptyArrayNodes() {
+        MutableMapNode mapNode = new MutableMapNode();
+        mapNode.set("custom.0.0", new ValueNode("val1"));
+        mapNode.set("custom.1", new ValueNode("val2"));
+
+        mapNode.remove("custom.0.0");
+
+        assertRemovedKey(mapNode, "custom.0.0");
+        assertRemovedKey(mapNode, "custom.1");
+        assertThat(mapNode.search("custom.0").value()).isEqualTo("val2");
+    }
+}


### PR DESCRIPTION
Add `set(String,TreeNode)` and `remove(String)` on `MutableTreeNode`.
These methods will ease the development of configuration providers.
